### PR TITLE
Add test code lens support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Besides the `lsp-mode` features, `lsp-dart` implements the [custom methods featu
 
 ![flutter-outline](https://github.com/emacs-lsp/lsp-dart/blob/master/screenshots/flutter-outline.png)
 
+### Run tests
+
+Run dart or flutter tests.
+
+![test](https://user-images.githubusercontent.com/7820865/79058546-cea92280-7c45-11ea-9a31-c55f3301f949.gif)
+
 ## Supported settings
 
 * `lsp-dart-sdk-dir` - Install directory for dart-sdk.

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ Besides the `lsp-mode` features, `lsp-dart` implements the [custom methods featu
 
 `lsp-dart-run-test-at-point` - Run single test at point.
 
-Or run a test interactively: 
+Running a test interactively: 
 
-![test](https://user-images.githubusercontent.com/7820865/79058546-cea92280-7c45-11ea-9a31-c55f3301f949.gif)
+![test](https://raw.githubusercontent.com/emacs-lsp/lsp-dart/screenshots/run-test.gif)
 
 ## Supported settings
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,11 @@ Besides the `lsp-mode` features, `lsp-dart` implements the [custom methods featu
 
 ### Run tests
 
-Run dart or flutter tests.
+`lsp-dart-run-test-file` - Run all tests from current test buffer.
+
+`lsp-dart-run-test-at-point` - Run single test at point.
+
+Or run a test interactively: 
 
 ![test](https://user-images.githubusercontent.com/7820865/79058546-cea92280-7c45-11ea-9a31-c55f3301f949.gif)
 

--- a/lsp-dart.el
+++ b/lsp-dart.el
@@ -409,9 +409,9 @@ If NAME is non nil, it will run only the test NAME."
                                   (+ (cl-search "(" name) 2)
                                   (- (lsp-dart--last-index-of ")" name) 1))))
           (test-arg (when name
-                      (concat  "--name '"
+                      (concat "--name '"
                                (lsp-dart--escape-test-name test-name)
-                               "'"))))
+                               "$'"))))
      (compilation-start (format "%s test %s %s"
                                 (lsp-dart--build-command buffer)
                                 (or test-arg "")


### PR DESCRIPTION
Add support for test run given the outline custom method from dart analysis server.

`lsp-dart`
![test](https://user-images.githubusercontent.com/7820865/79058546-cea92280-7c45-11ea-9a31-c55f3301f949.gif)

`vscode`
![image](https://user-images.githubusercontent.com/7820865/79058241-bc2cea00-7c41-11ea-9365-fa4a6f398270.png)
