### PR TITLE
Add lsp-dart-flutter-executable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
+## 1.17.6
+* Add `lsp-dart-flutter-executable`.
+
 ## 1.17.0
 * Add test tree feature.
-* Add `lsp-dart-test-show-tree`
+* Add `lsp-dart-test-show-tree`.
 
 ## 1.16.0
 * Improve tests backend and output.
@@ -35,19 +38,19 @@
 * Migrate lsp-dart to use lsp-protocol following lsp-mode.
 
 ## 1.11.9
-* Add Dart SDK version to `lsp-dart-version` command. 
+* Add Dart SDK version to `lsp-dart-version` command.
 
 ## 1.11.0
 * Add main code lens support, can be disable setting `lsp-dart-main-code-lens` to `nil`.
 
 ## 1.10.5
-* Add `lsp-dart-run-all-tests` command. 
+* Add `lsp-dart-run-all-tests` command.
 
 ## 1.10.0
-* Support for debugging Dart/Flutter tests. 
+* Support for debugging Dart/Flutter tests.
 * Add "Debug" code lens on tests.
-* Add `lsp-dart-debug-test-at-point` command. 
-* Add `lsp-dart-debug-last-test` command. 
+* Add `lsp-dart-debug-test-at-point` command.
+* Add `lsp-dart-debug-last-test` command.
 
 ## 1.9.0
 * Add `lsp-dart-visit-last-test` command.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ lsp-dart
 
 [![MELPA](https://melpa.org/packages/lsp-dart-badge.svg)](https://melpa.org/#/lsp-dart)
 [![MELPA stable](https://stable.melpa.org/packages/lsp-dart-badge.svg)](https://stable.melpa.org/#/lsp-dart)
-[![CI](https://github.com/emacs-lsp/lsp-dart/workflows/CI/badge.svg)](https://github.com/emacs-lsp/lsp-dart/actions) 
+[![CI](https://github.com/emacs-lsp/lsp-dart/workflows/CI/badge.svg)](https://github.com/emacs-lsp/lsp-dart/actions)
 [![Gitter](https://badges.gitter.im/emacs-lsp/lsp-mode.svg)](https://gitter.im/emacs-lsp/lsp-mode)
 
 Emacs Dart IDE using [lsp-mode](https://github.com/emacs-lsp/lsp-mode) to connect to [Dart Analysis Server](https://github.com/dart-lang/sdk/tree/master/pkg/analysis_server).
@@ -30,8 +30,8 @@ The following has a example to setup `lsp-dart`.
    (require 'use-package)))
 
 (use-package lsp-mode :ensure t)
-(use-package lsp-dart 
-  :ensure t 
+(use-package lsp-dart
+  :ensure t
   :hook (dart-mode . lsp))
 
 ;; Optional packages
@@ -82,7 +82,7 @@ Besides the `lsp-mode` features, `lsp-dart` implements the [custom methods featu
 
 `lsp-dart-debug-last-test` - Debug last ran test.
 
-Running a test interactively: 
+Running a test interactively:
 
 ![test](images/run-test.gif)
 
@@ -175,6 +175,7 @@ lsp-dart supports running Flutter and Dart commands as following:
 |:-------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|
 | `lsp-dart-sdk-dir`                               | The optional Dart SDK path. If nil and in a flutter project, it will try to find the dart SDK from Flutter SDK cache dir, otherwise it will search for a dart executable in `$PATH`. | `nil`             |
 | `lsp-dart-flutter-sdk-dir`                       | The optional Flutter SDK path. If nil, it will try to find the Flutter SDK from the `flutter` executable in `$PATH` and if not found, it will try in `$FLUTTER_ROOT`.                | `nil`             |
+| `lsp-dart-flutter-executable`                    | Flutter executable name.                                                                                                                                                             | `flutter`         |
 | `lsp-dart-server-command`                        | `analysis_server` executable to use                                                                                                                                                  | Check source file |
 | `lsp-dart-enable-sdk-formatter`                  | Whether to enable server formatting.                                                                                                                                                 | `t`               |
 | `lsp-dart-line-length`                           | Line length used by server formatter.                                                                                                                                                | 80                |

--- a/lsp-dart-utils.el
+++ b/lsp-dart-utils.el
@@ -41,13 +41,20 @@ FLUTTER_ROOT environment variable and the PATH environment variable."
   :risky t
   :type '(choice directory nil))
 
+(defcustom lsp-dart-flutter-executable "flutter"
+  "Flutter executable name.
+Useful if multiple Flutter installations are present."
+  :group 'lsp-dart
+  :risky nil
+  :type '(string))
+
 
 ;; Internal
 
 (defun lsp-dart--flutter-repo-p ()
   "Return non-nil if buffer is the flutter repository."
-  (if-let (bin-path (locate-dominating-file default-directory "flutter"))
-      (and (file-regular-p (expand-file-name "flutter" bin-path))
+  (if-let (bin-path (locate-dominating-file default-directory lsp-dart-flutter-executable))
+      (and (file-regular-p (expand-file-name lsp-dart-flutter-executable bin-path))
            (->> bin-path
                 (expand-file-name "cache/dart-sdk")
                 file-directory-p))))
@@ -94,7 +101,7 @@ Check for `lsp-dart-flutter-sdk-dir` then
 flutter executable on PATH then
 FLUTTER_ROOT environment variable."
   (or lsp-dart-flutter-sdk-dir
-      (-some-> (executable-find "flutter")
+      (-some-> (executable-find lsp-dart-flutter-executable)
         file-truename
         (locate-dominating-file "bin")
         file-truename)
@@ -120,7 +127,9 @@ FLUTTER_ROOT environment variable."
 
 (defun lsp-dart-flutter-command ()
   "Return the flutter executable from Flutter SDK dir."
-  (let* ((executable-path (if (eq system-type 'windows-nt) "bin/flutter.bat" "bin/flutter"))
+  (let* ((executable-path (if (eq system-type 'windows-nt)
+                              "bin/flutter.bat"
+                            (concat "bin/" lsp-dart-flutter-executable)))
          (command (expand-file-name executable-path (lsp-dart-get-flutter-sdk-dir))))
     (if (file-exists-p command)
         command

--- a/lsp-dart-utils.el
+++ b/lsp-dart-utils.el
@@ -45,8 +45,8 @@ FLUTTER_ROOT environment variable and the PATH environment variable."
   "Flutter executable name.
 Useful if multiple Flutter installations are present."
   :group 'lsp-dart
-  :risky nil
-  :type '(string))
+  :risky t
+  :type 'string)
 
 
 ;; Internal


### PR DESCRIPTION
Talked about opening an issue, but I think a pull-request will illustrate the problem better.
 
When installing Flutter with Nix one can choose to install one or more versions, stable, beta and dev. The flutter command to run these will differ, `flutter`, `flutter-beta` and `flutter-dev`. When using flutter-dev lsp-dart will not find or be able to run flutter command, as it's not called `flutter` but `flutter-dev`.

This pull-request adds the ability to customize flutter executable name. In my case I set it to `flutter-dev` and this seems to be working.

Warning: 
- When running windows the added variable `lsp-dart-flutter-executable` will not be used.
- Tests still use the hard coded "flutter" string. 
- Testing has been limited, the following has been done:
  - Opening a flutter project doesn't result in any errors. 
  - Checked output of `lsp-dart-get-flutter-sdk-dir` and `lsp-dart-flutter-command` and they both seem right. 

Feedback is welcome! 