### PR TITLE
Add the abilitie to lsp-dart to switch debugger according to version mentioned in the dart-dap

### DIFF
--- a/lsp-dart-dap.el
+++ b/lsp-dart-dap.el
@@ -166,6 +166,13 @@ Required to support 'Inspect Widget'."
  lsp-dart-dap-debugger-path
  lsp-dart-dap-extension-version)
 
+(dap-utils-vscode-update-function
+ "dap-dart"                    
+ "Dart-Code"                   
+ "Dart-Code"
+ lsp-dart-dap-extension-version
+ lsp-dart-dap-debugger-path)
+
 (defun lsp-dart-dap--populate-dart-start-file-args (conf)
   "Populate CONF with the required arguments for dart debug."
   (-> conf


### PR DESCRIPTION
    - call to *dap-utils-vscode-update-function*