### PR TITLE
Allow extra args to test command

### DIFF
--- a/lsp-dart-test-support.el
+++ b/lsp-dart-test-support.el
@@ -63,10 +63,15 @@ IGNORE-CASE is a optional arg to ignore the case sensitive on regex search."
       (lsp-dart-flutter-command)
     (lsp-dart-pub-command)))
 
+(defcustom lsp-dart-test-extra-args '()
+  "Extra arguments to be passed to test command (e.g: --no-sound-null-safety)."
+  :type '(repeat string)
+  :group 'lsp-dart)
+
 (defun lsp-dart-test--build-command-extra-args ()
   "Build the dart or flutter extra args."
   (if (lsp-dart-flutter-project-p)
-      '("test" "--machine")
+      (append '("test" "--machine") lsp-dart-test-extra-args)
     '("run" "test" "-r" "json")))
 
 (defun lsp-dart-test--build-test-name (names)


### PR DESCRIPTION
This will allow giving extra args when running tests, such as `flutter test --no-sound-null-safety`