### PR TITLE
Move comint to a network daemon

### DIFF
--- a/lsp-dart-flutter-daemon.el
+++ b/lsp-dart-flutter-daemon.el
@@ -21,7 +21,6 @@
 ;;
 ;;; Code:
 
-(require 'comint)
 (require 'dash)
 (require 'lsp-mode)
 
@@ -34,6 +33,11 @@
 (defvar lsp-dart-flutter-daemon-devices '())
 (defvar lsp-dart-flutter-daemon-commands '())
 (defvar lsp-dart-flutter-daemon-device-added-listeners '())
+
+(defcustom lsp-dart-flutter-daemon--port 9290
+  "Port to listen for connections on."
+  :group 'lsp-dart
+  :type 'integer)
 
 (defun lsp-dart-flutter-daemon--log (level msg &rest args)
   "Log for LEVEL, MSG with ARGS adding lsp-dart-flutter-daemon prefix."
@@ -48,18 +52,26 @@
 
 (defun lsp-dart-flutter-daemon--running-p ()
   "Return non-nil if the Flutter daemon is already running."
-  (comint-check-proc lsp-dart-flutter-daemon-buffer-name))
+  (process-status lsp-dart-flutter-daemon-name))
 
 (defun lsp-dart-flutter-daemon-start ()
   "Start the Flutter daemon."
   (unless (lsp-dart-flutter-daemon--running-p)
-    (let ((buffer (get-buffer-create lsp-dart-flutter-daemon-buffer-name)))
-      (make-comint-in-buffer lsp-dart-flutter-daemon-name buffer (lsp-dart-flutter-command) nil "daemon")
-      (with-current-buffer buffer
-        (unless (derived-mode-p 'lsp-dart-flutter-daemon-mode)
-          (lsp-dart-flutter-daemon-mode))
-        (setq-local comint-output-filter-functions #'lsp-dart-flutter-daemon--handle-responses))
-      (lsp-dart-flutter-daemon--send "device.enable"))))
+    (if (null (condition-case err
+                  (let ((proc (make-process
+                               :name lsp-dart-flutter-daemon-name
+                               :command `(,(lsp-dart-flutter-command) "daemon" "--listen-on-tcp-port" ,(number-to-string lsp-dart-flutter-daemon--port))
+                               :buffer lsp-dart-flutter-daemon-buffer-name
+                               :stderr (get-buffer-create (format "*%s stderr*" lsp-dart-flutter-daemon-name)))))
+                    (dolist (buf `(,lsp-dart-flutter-daemon-buffer-name ,(format "*%s stderr*" lsp-dart-flutter-daemon-name)))
+                      (when (get-buffer buf)
+                        (with-current-buffer (get-buffer buf)
+                          (special-mode)
+                          (read-only-mode))))
+                    (lsp-dart-flutter-daemon--send "device.enable")
+                    proc)
+                (file-error nil)))
+        (error "Failed to start a flutter daemon"))))
 
 (defun lsp-dart-flutter-daemon--build-command (id method &optional params)
   "Build a command from an ID and METHOD.
@@ -77,12 +89,12 @@ PARAMS is the optional method params."
   (when (string-prefix-p "[" (string-trim response))
     (--> response
          string-trim
-         (replace-regexp-in-string (regexp-quote "\n") "" it nil 'literal)
-         (replace-regexp-in-string (regexp-quote "][") "]\n[" it nil 'literal)
          (split-string it "\n")
-         (-map (lambda (el) (lsp-seq-first (lsp--read-json el))) it))))
+         (-map (lambda (el)
+                 (lsp--read-json (substring el 1 -1)))
+               it))))
 
-(defun lsp-dart-flutter-daemon--handle-responses (raw-response)
+(defun lsp-dart-flutter-daemon--handle-responses (raw-response callback)
   "Handle Flutter daemon response from RAW-RESPONSE."
   (-map (-lambda ((&FlutterDaemonResponse :id :event? :result?
                                           :params? (params &as &FlutterDaemonResponseParams? :level? :message?)))
@@ -93,15 +105,18 @@ PARAMS is the optional method params."
                 ("device.added" (lsp-dart-flutter-daemon--device-added params))
 
                 ("daemon.logMessage" (lsp-dart-flutter-daemon--log level? message?)))
-            (let* ((command (alist-get id lsp-dart-flutter-daemon-commands))
-                   (callback (plist-get command :callback)))
-              (when command
-                (setq lsp-dart-flutter-daemon-commands
-                      (lsp-dart-remove-from-alist id lsp-dart-flutter-daemon-commands)))
-              (when callback
-                (when result?
-                  (funcall callback result?))))))
+            (message "%S" `(,id ,result? ,event?))
+            (when callback
+              (when result?
+                (funcall callback result?)))))
         (lsp-dart-flutter-daemon--raw->response raw-response)))
+
+(defun lsp-dart-flutter-daemon--process-filter (process message &optional callback)
+  "Handle MESSAGE from PROCESS."
+  (message "[filter] Got %S from %S" message process)
+  (lsp-dart-flutter-daemon--handle-responses message callback)
+  (lambda ()
+    (delete-process process)))
 
 (defun lsp-dart-flutter-daemon--send (method &optional params callback)
   "Build and send command with METHOD with optional PARAMS.
@@ -110,9 +125,18 @@ of this command."
   (unless (lsp-dart-flutter-daemon--running-p)
     (lsp-dart-flutter-daemon-start))
   (let* ((id (lsp-dart-flutter-daemon--generate-command-id))
-         (command (lsp-dart-flutter-daemon--build-command id method params)))
-    (add-to-list 'lsp-dart-flutter-daemon-commands (cons id (list :callback callback)))
-    (comint-send-string (get-buffer-process lsp-dart-flutter-daemon-buffer-name) command)))
+         (command (lsp-dart-flutter-daemon--build-command id method params))
+         (client (open-network-stream
+                  "lsp-flutter-client"
+                  (get-buffer-create (format "*%s client*" lsp-dart-flutter-daemon-name))
+                  "localhost"
+                  (number-to-string lsp-dart-flutter-daemon--port))))
+    (set-process-filter-multibyte client t)
+    (set-process-coding-system client 'utf-8 'utf-8)
+    (set-process-filter client (lambda (proc msg)
+                                 (lsp-dart-flutter-daemon--process-filter proc msg callback)))
+    (set-process-sentinel client #'lsp-dart-flutter-daemon--process-sentinel)
+    (process-send-string client command)))
 
 (defun lsp-dart-flutter-daemon--device-removed (device)
   "Remove DEVICE from the devices list."
@@ -161,13 +185,6 @@ of this command."
            (add-to-list 'lsp-dart-flutter-daemon-device-added-listeners
                         (cons id (list :callback callback)))
            (lsp-dart-flutter-daemon--send "emulator.launch" params callback)))))))
-
-;;;###autoload
-(define-derived-mode lsp-dart-flutter-daemon-mode comint-mode lsp-dart-flutter-daemon-name
-  "Major mode for `lsp-dart-flutter-daemon-start`."
-  (setq comint-prompt-read-only nil)
-  (setq comint-process-echoes nil)
-  (setenv "PATH" (concat (lsp-dart-flutter-command) ":" (getenv "PATH"))))
 
 (provide 'lsp-dart-flutter-daemon)
 ;;; lsp-dart-flutter-daemon.el ends here


### PR DESCRIPTION
Refactor hacky comint implementation with a more robust and stable
version around the tcp version of the flutter daemon.

Currently debugging doesn't work and there's a slight hang on the initial buffer set-up (this can be offloaded asynchronously) but it has for the most part been supplanted. 

Raising this PR now to get feedback and assess the feasibility of such an implementation.