### PR TITLE
refactor: comint daemon to jsonrpc

### DIFF
--- a/Eask
+++ b/Eask
@@ -15,6 +15,7 @@
 (depends-on "dash")
 (depends-on "dart-mode")
 (depends-on "jsonrpc")
+(depends-on "ht") ; Remove after plists is implemented
 
 (development
  (depends-on "el-mock")

--- a/Eask
+++ b/Eask
@@ -14,6 +14,7 @@
 (depends-on "f")
 (depends-on "dash")
 (depends-on "dart-mode")
+(depends-on "jsonrpc")
 
 (development
  (depends-on "el-mock")

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ EMACS ?= emacs
 EASK ?= eask
 
 build:
+	$(EASK) install-deps
 	$(EASK) package
 	$(EASK) install
 

--- a/lsp-dart-flutter-daemon.el
+++ b/lsp-dart-flutter-daemon.el
@@ -144,7 +144,7 @@
                  :process (lambda ()
                             (make-process
                              :name lsp-dart-flutter-daemon-name
-                             :command `(,(lsp-dart-flutter-command) "daemon")
+                             :command `(,@(lsp-dart-flutter-command) "daemon")
                              :coding 'utf-8-emacs-unix
                              :connection-type 'pipe
                              :buffer lsp-dart-flutter-daemon-buffer-name

--- a/lsp-dart-flutter-daemon.el
+++ b/lsp-dart-flutter-daemon.el
@@ -21,7 +21,8 @@
 ;;
 ;;; Code:
 
-(require 'comint)
+(require 'jsonrpc)
+(require 'ht)
 (require 'dash)
 (require 'lsp-mode)
 
@@ -34,6 +35,90 @@
 (defvar lsp-dart-flutter-daemon-devices '())
 (defvar lsp-dart-flutter-daemon-commands '())
 (defvar lsp-dart-flutter-daemon-device-added-listeners '())
+
+(defvar lsp-dart-flutter-daemon--conn nil
+  "JSONRPC Connection object to the Flutter daemon process.")
+
+(defclass lsp-dart-flutter-daemon-connection (jsonrpc-process-connection) ()
+  "A connection based on stdio to connect to a Flutter daemon.")
+
+(cl-defmethod jsonrpc-connection-send ((conn lsp-dart-flutter-daemon-connection)
+                                       &rest args
+                                       &key method params &allow-other-keys)
+  "Implement send method to format JSON properly."
+  (when method
+    (plist-put args :method
+               (cond ((keywordp method) (substring (symbol-name method) 1))
+                     ((and method (symbolp method)) (symbol-name method))
+                     ((stringp method) method))))
+  (unless params
+    (cl-remf args :params))
+  (let ((json (concat "[" (jsonrpc--json-encode args) "]\r\n")))
+    (jsonrpc--log-event conn args 'client)
+    (process-send-string
+     (jsonrpc--process conn)
+     json)))
+
+(cl-defmethod initialize-instance ((conn lsp-dart-flutter-daemon-connection) _slots)
+  (cl-call-next-method)
+  (let ((proc (jsonrpc--process conn)))
+    (when proc
+      (set-process-filter proc #'lsp-dart-flutter-daemon--process-filter))))
+
+(defun lsp-dart-flutter-daemon--json-read-string (s)
+  (if (fboundp 'json-parse-string)
+      (json-parse-string s
+                         :object-type 'plist
+                         :false-object nil
+                         :null-object nil)
+    (let ((json-object-type 'plist)
+          (json-false :json-false)
+          (json-null nil))
+      (json-read-from-string s))))
+
+;; TODO: Greatly reduce this complexity
+(defun lsp-dart-flutter-daemon--process-filter (proc string)
+  "Invoked when a new STRING has arrived from PROC."
+  (when (buffer-live-p (process-buffer proc))
+    (with-current-buffer (process-buffer proc)
+      (let ((should-trim (not (string-match-p (regexp-quote "][") (string-trim string))))
+            (inhibit-read-only t))
+        (goto-char (process-mark proc))
+        (when (string-prefix-p "[" (string-trim string))
+          (--> string
+               string-trim
+               (replace-regexp-in-string (regexp-quote "\n") "" it nil 'literal)
+               (replace-regexp-in-string (regexp-quote "][") "," it nil 'literal)
+               (split-string it "\n")
+               (-map (lambda (response)
+                       (let ((hash-table (json-parse-string (if should-trim (substring response 1 -1) response)
+                                                            :object-type 'hash-table
+                                                            :false-object :json-false
+                                                            :null-object nil))
+                             (json-message (condition-case-unless-debug oops
+                                               (lsp-dart-flutter-daemon--json-read-string (if should-trim
+                                                                                              (substring response 1 -1)
+                                                                                            response))
+                                             (error
+                                              (jsonrpc--warn "Invalid JSON: %S %s"
+                                                             oops (buffer-string))
+                                              nil)))
+                             (conn (process-get proc 'jsonrpc-connection)))
+                         (when json-message
+                           (message "json: %S\nresponse: %S" json-message response)
+                           (if (plist-get json-message :error)
+                               (lsp-dart-flutter-daemon--log "ERROR" (plist-get json-message :error) (plist-get json-message :trace)))
+                           (if (plist-get json-message :event)
+                               (pcase (plist-get json-message :event)
+                                 ("device.removed" (lsp-dart-flutter-daemon--device-removed (gethash "params" hash-table)))
+                                 ("device.added" (lsp-dart-flutter-daemon--device-added (gethash "params" hash-table)))
+                                 ("daemon.connected" (lsp-dart-flutter-daemon--send "device.enable"))
+                                 ("daemon.logMessage" (lsp-dart-flutter-daemon--log (plist-get (plist-get json-message :params) :level) (plist-get json-message :params))))
+                             (with-temp-buffer
+                               (jsonrpc-connection-receive conn
+                                                           json-message)))))
+                       )
+                     it)))))))
 
 (defun lsp-dart-flutter-daemon--log (level msg &rest args)
   "Log for LEVEL, MSG with ARGS adding lsp-dart-flutter-daemon prefix."
@@ -48,61 +133,24 @@
 
 (defun lsp-dart-flutter-daemon--running-p ()
   "Return non-nil if the Flutter daemon is already running."
-  (comint-check-proc lsp-dart-flutter-daemon-buffer-name))
+  (and (not (null lsp-dart-flutter-daemon--conn))
+       (process-live-p (get-process lsp-dart-flutter-daemon-name))))
 
 (defun lsp-dart-flutter-daemon-start ()
   "Start the Flutter daemon."
   (unless (lsp-dart-flutter-daemon--running-p)
-    (let ((buffer (get-buffer-create lsp-dart-flutter-daemon-buffer-name))
-          (command (lsp-dart-flutter-command)))
-      (make-comint-in-buffer lsp-dart-flutter-daemon-name buffer (car command) nil (string-join (append (cdr command) '("daemon")) " "))
-      (with-current-buffer buffer
-        (unless (derived-mode-p 'lsp-dart-flutter-daemon-mode)
-          (lsp-dart-flutter-daemon-mode))
-        (setq-local comint-output-filter-functions #'lsp-dart-flutter-daemon--handle-responses))
-      (lsp-dart-flutter-daemon--send "device.enable"))))
-
-(defun lsp-dart-flutter-daemon--build-command (id method &optional params)
-  "Build a command from an ID and METHOD.
-PARAMS is the optional method params."
-  (let ((command (lsp-make-flutter-daemon-command :id id
-                                                  :method method)))
-    (when params
-      (lsp:set-flutter-daemon-command-params? command params))
-    (concat "["
-            (lsp--json-serialize command)
-            "]\n")))
-
-(defun lsp-dart-flutter-daemon--raw->response (response)
-  "Parse raw RESPONSE into a list of responses."
-  (when (string-prefix-p "[" (string-trim response))
-    (--> response
-         string-trim
-         (replace-regexp-in-string (regexp-quote "\n") "" it nil 'literal)
-         (replace-regexp-in-string (regexp-quote "][") "]\n[" it nil 'literal)
-         (split-string it "\n")
-         (-map (lambda (el) (lsp-seq-first (lsp--read-json el))) it))))
-
-(defun lsp-dart-flutter-daemon--handle-responses (raw-response)
-  "Handle Flutter daemon response from RAW-RESPONSE."
-  (-map (-lambda ((&FlutterDaemonResponse :id :event? :result?
-                                          :params? (params &as &FlutterDaemonResponseParams? :level? :message?)))
-          (if event?
-              (pcase event?
-                ("device.removed" (lsp-dart-flutter-daemon--device-removed params))
-
-                ("device.added" (lsp-dart-flutter-daemon--device-added params))
-
-                ("daemon.logMessage" (lsp-dart-flutter-daemon--log level? message?)))
-            (let* ((command (alist-get id lsp-dart-flutter-daemon-commands))
-                   (callback (plist-get command :callback)))
-              (when command
-                (setq lsp-dart-flutter-daemon-commands
-                      (lsp-dart-remove-from-alist id lsp-dart-flutter-daemon-commands)))
-              (when callback
-                (when result?
-                  (funcall callback result?))))))
-        (lsp-dart-flutter-daemon--raw->response raw-response)))
+    (let ((conn (lsp-dart-flutter-daemon-connection
+                 :name lsp-dart-flutter-daemon-name
+                 :process (lambda ()
+                            (make-process
+                             :name lsp-dart-flutter-daemon-name
+                             :command `(,(lsp-dart-flutter-command) "daemon")
+                             :coding 'utf-8-emacs-unix
+                             :connection-type 'pipe
+                             :buffer lsp-dart-flutter-daemon-buffer-name
+                             :stderr (get-buffer-create
+                                      (format "*%s stderr*" lsp-dart-flutter-daemon-name)))))))
+      (setq lsp-dart-flutter-daemon--conn conn))))
 
 (defun lsp-dart-flutter-daemon--send (method &optional params callback)
   "Build and send command with METHOD with optional PARAMS.
@@ -110,16 +158,29 @@ Call CALLBACK if provided when the receive a response with the built id
 of this command."
   (unless (lsp-dart-flutter-daemon--running-p)
     (lsp-dart-flutter-daemon-start))
-  (let* ((id (lsp-dart-flutter-daemon--generate-command-id))
-         (command (lsp-dart-flutter-daemon--build-command id method params)))
-    (add-to-list 'lsp-dart-flutter-daemon-commands (cons id (list :callback callback)))
-    (comint-send-string (get-buffer-process lsp-dart-flutter-daemon-buffer-name) command)))
+  (jsonrpc-async-request lsp-dart-flutter-daemon--conn
+                         method params
+                         :success-fn (lambda (result)
+                                       (funcall callback
+                                                (if (vectorp result)
+                                                    (-map #'lsp-dart-flutter-daemon--plist->hash-table result)
+                                                  (lsp-dart-flutter-daemon--plist->hash-table result))))))
 
 (defun lsp-dart-flutter-daemon--device-removed (device)
   "Remove DEVICE from the devices list."
   (--> (gethash "id" device)
        (lsp-dart-remove-from-alist it lsp-dart-flutter-daemon-devices)
        (setq lsp-dart-flutter-daemon-devices it)))
+
+(defun lsp-dart-flutter-daemon--plist->hash-table (plist &optional test)
+  "Create a hash table initialized from PLIST.
+
+Optionally use TEST to compare the hash keys."
+  (let ((ht (ht-create test)))
+    (dolist (pair (nreverse (-partition 2 plist)) ht)
+      (let ((key (substring (symbol-name (car pair)) 1))
+            (value (cadr pair)))
+        (ht-set! ht key value)))))
 
 (lsp-defun lsp-dart-flutter-daemon--device-added ((device &as &FlutterDaemonDevice :id))
   "Add DEVICE to the devices list."
@@ -162,13 +223,6 @@ of this command."
            (add-to-list 'lsp-dart-flutter-daemon-device-added-listeners
                         (cons id (list :callback callback)))
            (lsp-dart-flutter-daemon--send "emulator.launch" params callback)))))))
-
-;;;###autoload
-(define-derived-mode lsp-dart-flutter-daemon-mode comint-mode lsp-dart-flutter-daemon-name
-  "Major mode for `lsp-dart-flutter-daemon-start`."
-  (setq comint-prompt-read-only nil)
-  (setq comint-process-echoes nil)
-  (setenv "PATH" (concat (car (lsp-dart-flutter-command)) ":" (getenv "PATH"))))
 
 (provide 'lsp-dart-flutter-daemon)
 ;;; lsp-dart-flutter-daemon.el ends here

--- a/lsp-dart-flutter-daemon.el
+++ b/lsp-dart-flutter-daemon.el
@@ -160,10 +160,11 @@ of this command."
   (jsonrpc-async-request lsp-dart-flutter-daemon--conn
                          method params
                          :success-fn (lambda (result)
-                                       (funcall callback
-                                                (if (vectorp result)
-                                                    (-map #'lsp-dart-flutter-daemon--plist->hash-table result)
-                                                  (lsp-dart-flutter-daemon--plist->hash-table result))))))
+                                       (when result
+                                         (funcall callback
+                                                  (if (vectorp result)
+                                                      (-map #'lsp-dart-flutter-daemon--plist->hash-table result)
+                                                    (lsp-dart-flutter-daemon--plist->hash-table result)))))))
 
 (defun lsp-dart-flutter-daemon--device-removed (device)
   "Remove DEVICE from the devices list."

--- a/lsp-dart-flutter-daemon.el
+++ b/lsp-dart-flutter-daemon.el
@@ -87,8 +87,7 @@
         (when (string-prefix-p "[" (string-trim string))
           (--> string
                string-trim
-               (replace-regexp-in-string (regexp-quote "\n") "" it nil 'literal)
-               (replace-regexp-in-string (regexp-quote "][") "," it nil 'literal)
+               (replace-regexp-in-string (regexp-quote "},{") "}\n{" it nil 'literal)
                (split-string it "\n")
                (-map (lambda (response)
                        (let ((hash-table (json-parse-string (if should-trim (substring response 1 -1) response)

--- a/lsp-dart.el
+++ b/lsp-dart.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2022 Eric Dallo
 
 ;; Version: 1.23.0
-;; Package-Requires: ((emacs "26.3") (lsp-treemacs "0.3") (lsp-mode "7.0.1") (dap-mode "0.6") (f "0.20.0") (dash "2.14.1") (dart-mode "1.0.5") (jsonrpc "1.0.15"))
+;; Package-Requires: ((emacs "26.3") (lsp-treemacs "0.3") (lsp-mode "7.0.1") (dap-mode "0.6") (f "0.20.0") (dash "2.14.1") (dart-mode "1.0.5") (jsonrpc "1.0.15") (ht "2.2"))
 ;; Keywords: languages, extensions
 ;; URL: https://emacs-lsp.github.io/lsp-dart
 

--- a/lsp-dart.el
+++ b/lsp-dart.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2022 Eric Dallo
 
 ;; Version: 1.23.0
-;; Package-Requires: ((emacs "26.3") (lsp-treemacs "0.3") (lsp-mode "7.0.1") (dap-mode "0.6") (f "0.20.0") (dash "2.14.1") (dart-mode "1.0.5"))
+;; Package-Requires: ((emacs "26.3") (lsp-treemacs "0.3") (lsp-mode "7.0.1") (dap-mode "0.6") (f "0.20.0") (dash "2.14.1") (dart-mode "1.0.5") (jsonrpc "1.0.15"))
 ;; Keywords: languages, extensions
 ;; URL: https://emacs-lsp.github.io/lsp-dart
 


### PR DESCRIPTION
Change the hacky comint implementation to a more stable and robust
JSONRPC implementation.

A process is managed by emacs and commands are sent/recieved
asynchronously to that process.

Currently there still exists a couple of bugs I'm struggling to nail down
(mostly because I'm unfamiliar with the hash-table/dash combination):

- On startup, sometimes it errors because it sends the two startup messages at
  once. This should easily be rectified with a `listp` check when parsing
- Debugging emulators on linux fails, and I'm struggling to work out exactly
  why. I suspect something isn't being set correctly maybe in one of the
  listeners
  - However , debugging regular linux works fine and seems faster and more stable
  
Apologies for opening two PRs for the same thing, when I first tried getting
this working every request timed out so I looked into the tcp implementation.
This supersedes that now as it's much more simple.

Obseletes #164