### PR TITLE
Devtools improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,19 @@ matching names.
 
 You can also open the [Dart DevTools](https://dart.dev/tools/dart-devtools) on the current debug session with `lsp-dart-open-devtools`.
 
+It's also possible to spawn the devtools inside an
+[XWidgets](https://www.emacswiki.org/emacs/EmacsXWidgets) frame by enabling
+`lsp-dart-devtools-prefer-xwidgets` and ensuring that your emacs has proper
+support for xwidgets frames.
+
+NVIDIA users may have to enable the below environment variables:
+
+``` shell
+WEBKIT_DISABLE_COMPOSITING_MODE=1
+WEBKIT_FORCE_SANDBOX=0
+```
+
+
 ### Commands
 
 lsp-dart supports running Flutter and Dart commands as following:

--- a/lsp-dart-devtools.el
+++ b/lsp-dart-devtools.el
@@ -37,6 +37,13 @@
   :group 'lsp-dart
   :type 'string)
 
+(defcustom lsp-dart-devtools-prefer-xwidgets nil
+  "If t and xwidgets support exists, open the devtools in an xwidget-webkit
+  view.
+NOTE XWidgets are still quite buggy so only enable this if you know you have support"
+  :group 'lsp-dart
+  :type 'boolean)
+
 (defconst lsp-dart-devtools--buffer-name "*LSP Dart - DevTools*")
 
 (defun lsp-dart-devtools-log (msg &rest args)
@@ -133,7 +140,12 @@ If it is already activated or after activated successfully, call CALLBACK."
                                            (hide ,lsp-dart-devtools-hide-options)
                                            (theme ,lsp-dart-devtools-theme))))
          (url (concat "http://" uri "?" params)))
-    (browse-url url)))
+    (if (and lsp-dart-devtools-prefer-xwidgets
+             (featurep 'xwidget-internal))
+        (progn
+          (select-window (split-window (selected-window) nil 'right))
+          (xwidget-webkit-browse-url url))
+      (browse-url url))))
 
 
 ;;; Public interface

--- a/lsp-dart-devtools.el
+++ b/lsp-dart-devtools.el
@@ -38,7 +38,6 @@
   :type 'string)
 
 (defconst lsp-dart-devtools--buffer-name "*LSP Dart - DevTools*")
-(defconst lsp-dart-devtools--pub-list-packages-buffer-name "*LSP Dart - Pub list packages*")
 
 (defun lsp-dart-devtools-log (msg &rest args)
   "Custom logger for MSG and ARGS."
@@ -75,15 +74,9 @@ If URI is not found on buffer, schedule re-check."
 
 (defun lsp-dart-devtools--activated-p ()
   "Return non-nil if devtools is activated otherwise nil."
-  (lsp-dart-devtools--clean-buffer lsp-dart-devtools--pub-list-packages-buffer-name)
-  (let* ((pub (lsp-dart-pub-command))
-         (_proc (call-process pub
-                              nil
-                              lsp-dart-devtools--pub-list-packages-buffer-name
-                              nil
-                              "global" "list"))
-         (content (lsp-dart-devtools--buffer-whole-string lsp-dart-devtools--pub-list-packages-buffer-name)))
-    (string-match-p "devtools \\([0-9]\\.[0-9]\\.[0-9]\\)" content)))
+  (let ((output (shell-command-to-string
+                 (mapconcat 'identity `(,@(lsp-dart-pub-command) "global" "list") " "))))
+    (string-match-p "devtools \\([0-9]\\.[0-9]\\.[0-9]\\)" output)))
 
 (defun lsp-dart-devtools--activate (callback)
   "Activate Dart Devtools via pub then call CALLBACK."
@@ -95,7 +88,7 @@ If URI is not found on buffer, schedule re-check."
        (funcall callback))
      (lambda (_) (lsp-dart-devtools-log "Could not activate DevTools. \
 Try to activate manually running 'pub global activate devtools'"))
-     pub "global" "activate" "devtools")))
+     (mapconcat 'identity `(,@pub "global" "activate" "devtools") " "))))
 
 (defun lsp-dart-devtools--check-activated (callback)
   "Check if devtools is activated otherwise prompt for activate it.
@@ -120,13 +113,13 @@ If it is already activated or after activated successfully, call CALLBACK."
    (lambda ()
      (if-let ((uri (lsp-workspace-get-metadata "dart-debug-devtools-uri")))
       (funcall callback uri)
-    (let* ((pub (lsp-dart-pub-command))
-           (proc (start-process "Start DevTools"
-                                lsp-dart-devtools--buffer-name
-                                pub "global" "run" "devtools"
-                                "--machine"
-                                "--enable-notifications"
-                                "--try-ports" "10")))
+      (let* ((pub (lsp-dart-pub-command))
+             (proc (apply #'start-process "Start DevTools"
+                          lsp-dart-devtools--buffer-name
+                          `(,@pub "global" "run" "devtools"
+                                  "--machine"
+                                  "--enable-notifications"
+                                  "--try-ports" "10"))))
       (add-hook 'dap-terminated-hook (-partial #'lsp-dart-devtools--kill-proc proc))
       (when lsp-dart-devtools--check-uri-timer
         (cancel-timer lsp-dart-devtools--check-uri-timer))


### PR DESCRIPTION
lsp-dart-pub-command has recently changed to produce a list instead,
which breaks all the places it's expected in devtools.

Also add opt-in support for opening the devtools in an xwidgets frame