### PR TITLE
Revert "feat: add new option for devtools xwidgets support"

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,19 +150,6 @@ matching names.
 
 You can also open the [Dart DevTools](https://dart.dev/tools/dart-devtools) on the current debug session with `lsp-dart-open-devtools`.
 
-It's also possible to spawn the devtools inside an
-[XWidgets](https://www.emacswiki.org/emacs/EmacsXWidgets) frame by enabling
-`lsp-dart-devtools-prefer-xwidgets` and ensuring that your emacs has proper
-support for xwidgets frames.
-
-NVIDIA users may have to enable the below environment variables:
-
-``` shell
-WEBKIT_DISABLE_COMPOSITING_MODE=1
-WEBKIT_FORCE_SANDBOX=0
-```
-
-
 ### Commands
 
 lsp-dart supports running Flutter and Dart commands as following:

--- a/lsp-dart-devtools.el
+++ b/lsp-dart-devtools.el
@@ -37,13 +37,6 @@
   :group 'lsp-dart
   :type 'string)
 
-(defcustom lsp-dart-devtools-prefer-xwidgets nil
-  "If t and xwidgets support exists, open the devtools in an xwidget-webkit
-  view.
-NOTE XWidgets are still quite buggy so only enable this if you know you have support"
-  :group 'lsp-dart
-  :type 'boolean)
-
 (defconst lsp-dart-devtools--buffer-name "*LSP Dart - DevTools*")
 
 (defun lsp-dart-devtools-log (msg &rest args)
@@ -140,12 +133,7 @@ If it is already activated or after activated successfully, call CALLBACK."
                                            (hide ,lsp-dart-devtools-hide-options)
                                            (theme ,lsp-dart-devtools-theme))))
          (url (concat "http://" uri "?" params)))
-    (if (and lsp-dart-devtools-prefer-xwidgets
-             (featurep 'xwidget-internal))
-        (progn
-          (select-window (split-window (selected-window) nil 'right))
-          (xwidget-webkit-browse-url url))
-      (browse-url url))))
+    (browse-url url)))
 
 
 ;;; Public interface


### PR DESCRIPTION
This reverts commit 65b308b4d71e446c663006878a60a501c7fae857.

After more extensive testing, seems it was a mistake that I got it working :sweat_smile: 

xwidget-webkit needs more work to be able to adequately support this.