### PR TITLE
Remove emacs-snapshot

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,6 @@ jobs:
           - 27.1
           - 27.2
           - 28.1
-          - snapshot
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Should make CI pass, there's an on-going bug RE: loaddefs

EDIT: it doesn't so remove it for now at least