### PR TITLE
Handle dart language-server

### DIFF
--- a/lsp-dart-utils.el
+++ b/lsp-dart-utils.el
@@ -90,10 +90,11 @@ Used by features that needs to know project entrypoint like DAP support."
       (eq lsp-dart--project-type-cache 'flutter)
     (let ((flutter-project? (or (-when-let (pubspec-path (-some->> (lsp-dart-get-project-root)
                                                            (expand-file-name "pubspec.yaml")))
-                                  (with-temp-buffer
-                                    (insert-file-contents (-some->> (lsp-dart-get-project-root) (expand-file-name "pubspec.yaml")))
-                                    (goto-char (point-min))
-                                    (re-search-forward "sdk\s*:\s*flutter" nil t)))
+                                  (when (file-exists-p pubspec-path)
+                                    (with-temp-buffer
+                                      (insert-file-contents (-some->> (lsp-dart-get-project-root) (expand-file-name "pubspec.yaml")))
+                                      (goto-char (point-min))
+                                      (re-search-forward "sdk\s*:\s*flutter" nil t))))
                                 (lsp-dart--flutter-repo-p))))
       (lsp-dart--set-project-type-cache flutter-project?)
       flutter-project?)))

--- a/lsp-dart-utils.el
+++ b/lsp-dart-utils.el
@@ -145,7 +145,8 @@ FLUTTER_ROOT environment variable."
   (let* ((command (lsp-dart--executable-find "dart" (lsp-dart-get-sdk-dir))))
     (if command
         command
-      (lsp-dart-log "Dart command not found in path '%s'" command))))
+      (lsp-dart-log "Dart command not found in path '%s'" command)
+      nil)))
 
 (defun lsp-dart-pub-command ()
   "Return the pub executable path from Dart SDK path."

--- a/lsp-dart.el
+++ b/lsp-dart.el
@@ -110,11 +110,25 @@ If unspecified, diagnostics will not be generated."
         (append (list (file-name-directory (buffer-file-name))) lsp-dart-extra-library-directories)
       lsp-dart-extra-library-directories)))
 
+(defun lsp-dart--dart-capabiliities (&optional sdk-root)
+  "Given an SDK-ROOT, return capabilities for that dart version.
+Default to `lsp-dart-get-sdk-dir' if no root is passed.
+Returns nil if an invalid SDK-ROOT has been passed."
+  (when-let* ((root (or sdk-root lsp-dart-sdk-dir (lsp-dart-get-sdk-dir)))
+              (dart-version (string-trim
+                             (with-temp-buffer
+                               (insert-file-contents (expand-file-name "version" root))
+                               (buffer-string)))))
+    `((canUseLanguageServer . ,(version<= "3.14.4" dart-version)))))
+
 (defun lsp-dart--server-command ()
   "Generate LSP startup command."
   (or lsp-dart-server-command
       (list (lsp-dart-dart-command)
-            "language-server"
+            (if (alist-get 'canUseLanguageServer (lsp-dart--dart-capabiliities))
+                "language-server"
+              (expand-file-name "bin/snapshots/analysis_server.dart.snapshot" (lsp-dart-get-sdk-dir))
+              "--lsp")
             "--client-id emacs.lsp-dart"
             (format "--client-version %s" lsp-dart-version-string))))
 

--- a/lsp-dart.el
+++ b/lsp-dart.el
@@ -114,8 +114,7 @@ If unspecified, diagnostics will not be generated."
   "Generate LSP startup command."
   (or lsp-dart-server-command
       (list (lsp-dart-dart-command)
-            (expand-file-name (f-join (lsp-dart-get-sdk-dir) "bin/snapshots/analysis_server.dart.snapshot"))
-            "--lsp"
+            "language-server"
             "--client-id emacs.lsp-dart"
             (format "--client-version %s" lsp-dart-version-string))))
 

--- a/test/lsp-dart-test.el
+++ b/test/lsp-dart-test.el
@@ -54,14 +54,26 @@
 
 (ert-deftest lsp-dart--server-command--default-test ()
   (with-mock
-    (stub lsp-dart-dart-command => "/sdk/bin/dart")
-    (stub lsp-dart-get-sdk-dir => "/sdk")
-    (should (equal (lsp-dart--server-command)
-                   `("/sdk/bin/dart"
-                     ,(f-expand "/sdk/bin/snapshots/analysis_server.dart.snapshot" (f-root))
-                     "--lsp"
-                     "--client-id emacs.lsp-dart"
-                     ,(concat "--client-version " lsp-dart-version-string))))))
+   (stub lsp-dart-dart-command => "/sdk/bin/dart")
+   (stub lsp-dart-get-sdk-dir => "/sdk")
+   (stub lsp-dart-get-dart-version => "2.14.1")
+   (should (equal (lsp-dart--server-command)
+                  `("/sdk/bin/dart"
+                    ,(f-expand "/sdk/bin/snapshots/analysis_server.dart.snapshot" (f-root))
+                    "--lsp"
+                    "--client-id emacs.lsp-dart"
+                    ,(concat "--client-version " lsp-dart-version-string))))))
+
+(ert-deftest lsp-dart--server-command--lsp-test ()
+  (with-mock
+   (stub lsp-dart-dart-command => "/sdk/bin/dart")
+   (stub lsp-dart-get-sdk-dir => "/sdk")
+   (stub lsp-dart-get-dart-version => "2.14.4")
+   (should (equal (lsp-dart--server-command)
+                  `("/sdk/bin/dart"
+                    "language-server"
+                    "--client-id emacs.lsp-dart"
+                    ,(concat "--client-version " lsp-dart-version-string))))))
 
 (ert-deftest lsp-dart-version--test ()
   (with-mock

--- a/test/lsp-dart-utils-test.el
+++ b/test/lsp-dart-utils-test.el
@@ -32,7 +32,7 @@
 (ert-deftest lsp-dart--flutter-repo-p--not-flutter-executable-test ()
   (with-mock
     (mock (locate-dominating-file * "flutter") => "/not-sdk/bin")
-    (mock (file-regular-p "/sdk/bin/flutter") => nil)
+    (stub file-regular-p => nil)
     (should-not (lsp-dart--flutter-repo-p))))
 
 (ert-deftest lsp-dart--flutter-repo-p--not-flutter-executable-test ()


### PR DESCRIPTION
The dart-sdk that comes with flutter doesn't include the snapshots by
default.

This is also the recommended approach according to the docs.