### PR TITLE
Allow detection of snap installs on linux systems

### DIFF
--- a/lsp-dart-utils.el
+++ b/lsp-dart-utils.el
@@ -118,6 +118,14 @@ Order is important."
       (append list (list value))
     list))
 
+(defun lsp-dart-flutter-snap-install-p ()
+  ;; Detecting whether this is a Linux system with a Snap style install
+  (and (string= system-type "gnu/linux")
+       (let ((first-dir (-some-> (executable-find lsp-dart-flutter-executable) f-split cdr car)))
+	 (and first-dir
+	      (string= first-dir "snap")
+	      (file-exists-p "~/snap/flutter/common/flutter/bin/flutter")))))
+
 
 ;; SDKs
 
@@ -132,6 +140,7 @@ is used in preference."
           (if (file-exists-p dart-sdk)
               dart-sdk
             (error "Dart SDK not found inside flutter cache dir %s.  Consider setting `lsp-dart-sdk-dir` variable" dart-sdk))))
+      (and (lsp-dart-flutter-snap-install-p) "~/snap/flutter/common/flutter/bin/cache/dart-sdk")
       (-some-> (executable-find "dart")
         file-truename
         (locate-dominating-file "bin")
@@ -143,6 +152,7 @@ Check for `lsp-dart-flutter-sdk-dir` then
 flutter executable on PATH then
 FLUTTER_ROOT environment variable."
   (or lsp-dart-flutter-sdk-dir
+      (and (lsp-dart-flutter-snap-install-p) "~/snap/flutter/common/flutter")
       (-some-> (executable-find lsp-dart-flutter-executable)
         file-truename
         (locate-dominating-file "bin")

--- a/test/lsp-dart-utils-test.el
+++ b/test/lsp-dart-utils-test.el
@@ -66,6 +66,7 @@
   (let ((dart-command (lsp-dart-test-command-fixture)))
     (lsp-dart-test-from-dart-project
      (mock (executable-find "dart") => dart-command)
+     (mock (lsp-dart-flutter-snap-install-p) => nil)
      (should (equal (lsp-dart-get-sdk-dir) (concat (-> dart-command
                                                        f-parent
                                                        f-parent)
@@ -81,14 +82,27 @@
      (mock (file-exists-p dart-sdk) => t)
      (should (equal (lsp-dart-get-sdk-dir) dart-sdk)))))
 
+(ert-deftest lsp-dart-get-sdk-dir--snap-install-test ()
+  (lsp-dart-test-from-dart-project
+   (mock (lsp-dart-flutter-snap-install-p) => t)
+   (should (equal (lsp-dart-get-sdk-dir) "~/snap/flutter/common/flutter/bin/cache/dart-sdk"))))
+
 (ert-deftest lsp-dart-get-sdk-dir--project-without-dart-on-path-test ()
   (lsp-dart-test-from-dart-project
    (mock (executable-find "dart") => nil)
+   (mock (lsp-dart-flutter-snap-install-p) => nil)
    (should (equal (lsp-dart-get-sdk-dir) nil))))
 
 (ert-deftest lsp-dart-get-flutter-sdk-dir--custom-dir-test ()
   (let ((lsp-dart-flutter-sdk-dir "/some/sdk"))
     (should (equal (lsp-dart-get-flutter-sdk-dir) "/some/sdk"))))
+
+(ert-deftest lsp-dart-get-flutter-sdk-dir--snap-install-test ()
+  (lsp-dart-test-from-flutter-project
+   (let ((system-type "gnu/linux"))
+     (mock (executable-find lsp-dart-flutter-executable) => "/snap/bin/flutter")
+     (mock (file-exists-p "~/snap/flutter/common/flutter/bin/flutter") => t)
+     (should (equal (lsp-dart-get-flutter-sdk-dir) "~/snap/flutter/common/flutter")))))
 
 (ert-deftest lsp-dart-get-flutter-sdk-dir--with-flutter-on-path-test ()
   (let ((flutter-command (lsp-dart-test-flutter-command-fixture)))


### PR DESCRIPTION
Reading issue #107 which has hit me a couple of times now, it seems like treating snap as an edge-case was the best possible solution. This patch implements that edge-case.