### PR TITLE
fix: Drop support for Emacs 26.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         emacs-version:
-          - 26.3
           - 27.1
           - 27.2
           - 28.1

--- a/Eask
+++ b/Eask
@@ -12,7 +12,7 @@
 (source "gnu")
 (source "melpa")
 
-(depends-on "emacs" "26.3")
+(depends-on "emacs" "27.1")
 (depends-on "lsp-treemacs")
 (depends-on "lsp-mode")
 (depends-on "dap-mode")

--- a/lsp-dart.el
+++ b/lsp-dart.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2022 Eric Dallo
 
 ;; Version: 1.24.2
-;; Package-Requires: ((emacs "26.3") (lsp-treemacs "0.3") (lsp-mode "7.0.1") (dap-mode "0.6") (f "0.20.0") (dash "2.14.1") (dart-mode "1.0.5") (jsonrpc "1.0.15") (ht "2.2"))
+;; Package-Requires: ((emacs "27.1") (lsp-treemacs "0.3") (lsp-mode "7.0.1") (dap-mode "0.6") (f "0.20.0") (dash "2.14.1") (dart-mode "1.0.5") (jsonrpc "1.0.15") (ht "2.2"))
 ;; Keywords: languages, extensions
 ;; URL: https://emacs-lsp.github.io/lsp-dart
 


### PR DESCRIPTION
See https://github.com/emacs-lsp/lsp-mode/pull/4126.