### PR TITLE
Find connected devices instead of emulators only

### DIFF
--- a/lsp-dart-flutter-daemon.el
+++ b/lsp-dart-flutter-daemon.el
@@ -208,7 +208,7 @@ of this command."
 (defun lsp-dart-flutter-daemon-get-devices (callback)
   "Call CALLBACK with the available emulators and devices from Flutter daemon."
   (lsp-dart-flutter-daemon--send
-   "emulator.getEmulators"
+   "device.getDevices"
    nil
    (-lambda (emulators)
      (let ((devices-excluding-emulators (-remove (-lambda ((&FlutterDaemonDevice :emulator-id?))


### PR DESCRIPTION
Hi,

I couldn't find my devices when I ran `dap-debug` and selected `Flutter :: Debug`.

I am not an expert, but with this change the devices are found and I am able to debug the app.

Hope it helps!!