### PR TITLE
 Added `lsp-dart-sdk-dir` and `lsp-dart-flutter-sdk-dir` variables to Quickstart in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ The following has a example to setup `lsp-dart`.
 
 (setq gc-cons-threshold (* 100 1024 1024)
       read-process-output-max (* 1024 1024))
+
+(setq lsp-dart-flutter-sdk-dir "<your Flutter directory>")
+(setq lsp-dart-sdk-dir "<your Flutter directory>/bin/cache/dart-sdk")
 ```
 
 ## Features


### PR DESCRIPTION
These two variables were not set in the Quickstart...