### PR TITLE
ci: Exclude macos tests below 28.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,9 @@ jobs:
           - os: windows-latest
             emacs-version: snapshot
             experimental: true
+        exclude:
+          - os: macos-latest
+            emacs-version: 27.2
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
See https://github.com/purcell/setup-emacs/issues/48.